### PR TITLE
Fix escaping for MarkdownV2 outputs

### DIFF
--- a/db.py
+++ b/db.py
@@ -68,6 +68,13 @@ async def is_admin(uid: int) -> bool:
         )
         return await cur.fetchone() is not None
 
+async def user_exists(uid: int) -> bool:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT 1 FROM users WHERE id = ?", (uid,)
+        )
+        return await cur.fetchone() is not None
+
 async def set_admin(uid: int, value: bool):
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(


### PR DESCRIPTION
## Summary
- properly escape content destined for MarkdownV2
- add helper function `md2`
- permit non-admin registered users to run `/report`

## Testing
- `python -m py_compile main.py db.py scraper.py`
