### PR TITLE
Fix duplicate fields in scrape

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -81,11 +81,6 @@ async def scrape(url: str) -> dict:
     drawdown = _num((stats_label("By Equity:") or {}).get_text())
     monthly = _num((stats_label("Monthly growth:") or {}).get_text())
 
-    started_text = (by_label("Started:") or {}).get_text(strip=True)
-    m = re.search(r"(\d{4})", started_text or "")
-    start_year = int(m.group(1)) if m else None
-
-    latest_trade = (by_label("Latest trade:") or {}).get_text(strip=True)
 
     trades = _num((stats_label("Trades:") or {}).get_text())
     profit_trades = _num((stats_label("Profit Trades:") or {}).get_text())
@@ -103,6 +98,4 @@ async def scrape(url: str) -> dict:
         "trades": int(trades) if trades is not None else None,
         "profit_trades": int(profit_trades) if profit_trades is not None else None,
         "loss_trades": int(loss_trades) if loss_trades is not None else None,
-        "start_year": start_year,
-        "latest_trade": latest_trade,
     }


### PR DESCRIPTION
## Summary
- simplify scraper by removing duplicate start_year and latest_trade fields

## Testing
- `python -m py_compile scraper.py`
- `python -m py_compile main.py`
