### PR TITLE
Support custom auth cookie for scraping

### DIFF
--- a/main.py
+++ b/main.py
@@ -377,6 +377,20 @@ async def report_cmd(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         lines.append(f"{sid}: " + ", ".join(parts))
     await update.message.reply_text("\n".join(lines))
 
+async def setcookie_cmd(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    uid = update.effective_user.id
+    if not await db.is_admin(uid):
+        await update.message.reply_text("⛔ Unauthorized")
+        return
+    text = update.message.text or ""
+    parts = text.split(None, 1)
+    if len(parts) < 2:
+        await update.message.reply_text("Usage: /setcookie <cookie>")
+        return
+    cookie = parts[1].strip()
+    await db.set_auth_cookie(cookie)
+    await update.message.reply_text("Cookie saved.")
+
 # ---------- bootstrap ----------
 if __name__ == "__main__":
     if not BOT_TOKEN:
@@ -392,6 +406,7 @@ if __name__ == "__main__":
     app.add_handler(CommandHandler("start", start))
     app.add_handler(CommandHandler("me", me_cmd))
     app.add_handler(CommandHandler("report", report_cmd))
+    app.add_handler(CommandHandler("setcookie", setcookie_cmd))
     app.add_handler(CallbackQueryHandler(menu_cb))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, text))
 

--- a/scraper.py
+++ b/scraper.py
@@ -4,13 +4,19 @@ import time
 import aiohttp
 from bs4 import BeautifulSoup
 
+import db
+
 UA = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/120.0 Safari/537.36"
 )
 
 async def fetch_html(url: str) -> str:
-    async with aiohttp.ClientSession(headers={"User-Agent": UA}) as s:
+    headers = {"User-Agent": UA}
+    cookie = await db.get_auth_cookie()
+    if cookie:
+        headers["Cookie"] = cookie
+    async with aiohttp.ClientSession(headers=headers) as s:
         async with s.get(url) as r:
             r.raise_for_status()
             return await r.text()


### PR DESCRIPTION
## Summary
- store a persistent auth cookie in the database
- add `/setcookie` command for admins
- send the stored cookie with requests when scraping

## Testing
- `ruff check .`