### PR TITLE
Implement cookie validity test via subscriptions

### DIFF
--- a/main.py
+++ b/main.py
@@ -379,6 +379,26 @@ async def setcookie_cmd(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     await db.set_auth_cookie(cookie)
     await update.message.reply_text("Cookie saved.")
 
+
+async def testcookie_cmd(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    uid = update.effective_user.id
+    if not await db.is_admin(uid):
+        await update.message.reply_text("⛔ Unauthorized")
+        return
+    async with scraper.session() as sess:
+        ok = await scraper.test_cookie(session=sess)
+    await update.message.reply_text("✅ Cookie valid" if ok else "❌ Cookie invalid")
+
+
+async def showcookie_cmd(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    uid = update.effective_user.id
+    if not await db.is_admin(uid):
+        await update.message.reply_text("⛔ Unauthorized")
+        return
+    cookie = await db.get_auth_cookie()
+    text = cookie if cookie else "No cookie set."
+    await update.message.reply_text(text)
+
 # ---------- bootstrap ----------
 if __name__ == "__main__":
     if not BOT_TOKEN:
@@ -394,6 +414,8 @@ if __name__ == "__main__":
     app.add_handler(CommandHandler("start", start))
     app.add_handler(CommandHandler("me", me_cmd))
     app.add_handler(CommandHandler("setcookie", setcookie_cmd))
+    app.add_handler(CommandHandler("testcookie", testcookie_cmd))
+    app.add_handler(CommandHandler("showcookie", showcookie_cmd))
     app.add_handler(CallbackQueryHandler(menu_cb))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, text))
 

--- a/scraper.py
+++ b/scraper.py
@@ -44,6 +44,26 @@ async def fetch_html(url: str, session: aiohttp.ClientSession | None = None) -> 
         await session.close()
     return html
 
+
+async def test_cookie(session: aiohttp.ClientSession | None = None) -> bool:
+    """Check whether the stored auth cookie grants access to subscriptions."""
+    own = session is None
+    if own:
+        session = await create_session()
+    assert session is not None
+    try:
+        async with session.get(
+            "https://www.mql5.com/en/signals/subscriptions",
+            allow_redirects=True,
+        ) as r:
+            final = str(r.url)
+            return r.status == 200 and "/en/signals/subscriptions" in final
+    except Exception:
+        return False
+    finally:
+        if own:
+            await session.close()
+
 def _num(text):
     if text is None:
         return None


### PR DESCRIPTION
## Summary
- add `test_cookie` helper to validate cookie using subscriptions page
- expose `/testcookie` command in the Telegram bot
- keep admin-only `/showcookie` command

## Testing
- `python -m py_compile main.py db.py scraper.py`
- `pytest -q` *(fails: command not found)*