### PR TITLE
Fix subscription scraping

### DIFF
--- a/main.py
+++ b/main.py
@@ -406,13 +406,18 @@ async def syncsubs_cmd(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         return
     await update.message.reply_text("Fetching subscriptions…")
     async with scraper.session() as sess:
+        if not await scraper.test_cookie(session=sess):
+            await update.message.reply_text("❌ Cookie invalid")
+            return
         subs = await scraper.list_subscriptions(session=sess)
     added = 0
     for s in subs:
         if not await db.signal_exists(s["id"]):
             await db.add_signal(s["id"], s["url"], name=s.get("name"), auto=True)
             added += 1
-    await update.message.reply_text(f"Added {added} new signal(s).")
+    await update.message.reply_text(
+        f"Found {len(subs)} subscription(s). Added {added} new signal(s)."
+    )
 
 
 async def showcookie_cmd(update: Update, ctx: ContextTypes.DEFAULT_TYPE):

--- a/scraper.py
+++ b/scraper.py
@@ -71,17 +71,21 @@ async def list_subscriptions(session: aiohttp.ClientSession | None = None) -> li
     if not table:
         return results
     rows = table.find_all("div", class_="row")
+    seen = set()
     for row in rows:
         link = None
         for a in row.find_all("a", href=True):
             href = a.get("href", "")
-            m = re.match(r"^/(?:[a-z]{2}/)?signals/(\d+)$", href)
+            m = re.match(r"^/(?:[a-z]{2}/)?signals/(?!subscription/)(\d+)", href)
             if m:
                 link = a
                 break
         if not link:
             continue
         sid = m.group(1)
+        if sid in seen:
+            continue
+        seen.add(sid)
         url = "https://www.mql5.com" + link["href"]
         name = link.get_text(strip=True)
         results.append({"id": sid, "url": url, "name": name})


### PR DESCRIPTION
## Summary
- handle query parameters when parsing subscription links
- avoid duplicate subscription IDs

## Testing
- `python -m py_compile db.py main.py scraper.py`
